### PR TITLE
add inet_pton implementation for windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,9 @@
+PKG_LIBS = -lboost_system -lboost_regex
+PKG_CPPFLAGS = -UNDEBUG -g
+
+IPTOOLS_OBJECTS = asio_bindings.o iptools.o RcppExports.o windows/inet_pton.o
+OBJECTS = $(IPTOOLS_OBJECTS)
+
+all: $(SHLIB)
+
+windows/%.o: windows/%.c

--- a/src/asio_bindings.h
+++ b/src/asio_bindings.h
@@ -1,5 +1,11 @@
 #include <Rcpp.h>
 #include <boost/asio.hpp>
+
+#ifdef _WIN32
+# include <windows.h>
+# include "windows/inet_v6defs.h"
+#endif
+
 using namespace Rcpp;
 
 #ifndef __ASIO_BINDINGS__

--- a/src/inet_pton.h
+++ b/src/inet_pton.h
@@ -1,0 +1,10 @@
+#ifndef IPTOOLS_INET_PTON_H
+#define IPTOOLS_INET_PTON_H
+
+#ifndef _WIN32
+# include <arpa/inet.h>
+#else
+# include "windows/inet_v6defs.h"
+#endif
+
+#endif /* IPTOOLS_INET_PTON_H */

--- a/src/windows/inet_pton.c
+++ b/src/windows/inet_pton.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 1996,1999 by Internet Software Consortium.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ * ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+ * CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ */
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <winsock2.h>	/* needed to define AF_ values on Windows */
+
+#define EAFNOSUPPORT    WSAEAFNOSUPPORT
+
+#include <string.h>
+#include <errno.h>
+
+#include "inet_v6defs.h"
+
+#ifndef NS_INADDRSZ
+#define NS_INADDRSZ	4
+#endif
+#ifndef NS_IN6ADDRSZ
+#define NS_IN6ADDRSZ	16
+#endif
+#ifndef NS_INT16SZ
+#define NS_INT16SZ	2
+#endif
+
+/*
+ * WARNING: Don't even consider trying to compile this on a system where
+ * sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.
+ */
+
+#ifdef AF_INET
+static int	inet_pton4 __P((const char *src, u_char *dst));
+#endif
+#ifdef AF_INET6
+static int	inet_pton6 __P((const char *src, u_char *dst));
+#endif
+
+/* int
+ * inet_pton(af, src, dst)
+ *	convert from presentation format (which usually means ASCII printable)
+ *	to network format (which is usually some kind of binary format).
+ * return:
+ *	1 if the address was valid for the specified address family
+ *	0 if the address wasn't valid (`dst' is untouched in this case)
+ *	-1 if some other error occurred (`dst' is untouched in this case, too)
+ * author:
+ *	Paul Vixie, 1996.
+ */
+__declspec(dllimport)
+int
+inet_pton(af, src, dst)
+	int af;
+	const char *src;
+	void *dst;
+{
+	switch (af) {
+#ifdef AF_INET
+	case AF_INET:
+		return (inet_pton4(src, dst));
+#endif
+#ifdef AF_INET6
+	case AF_INET6:
+		return (inet_pton6(src, dst));
+#endif
+	default:
+		errno = EAFNOSUPPORT;
+		return (-1);
+	}
+	/* NOTREACHED */
+}
+
+#ifdef AF_INET
+/* int
+ * inet_pton4(src, dst)
+ *	like inet_aton() but without all the hexadecimal and shorthand.
+ * return:
+ *	1 if `src' is a valid dotted quad, else 0.
+ * notice:
+ *	does not touch `dst' unless it's returning 1.
+ * author:
+ *	Paul Vixie, 1996.
+ */
+static int
+inet_pton4(src, dst)
+	const char *src;
+	u_char *dst;
+{
+	static const char digits[] = "0123456789";
+	int saw_digit, octets, ch;
+	u_char tmp[NS_INADDRSZ], *tp;
+
+	saw_digit = 0;
+	octets = 0;
+	*(tp = tmp) = 0;
+	while ((ch = *src++) != '\0') {
+		const char *pch;
+
+		if ((pch = strchr(digits, ch)) != NULL) {
+			size_t new = *tp * 10 + (pch - digits);
+
+			if (new > 255)
+				return (0);
+			*tp = (u_char) new;
+			if (! saw_digit) {
+				if (++octets > 4)
+					return (0);
+				saw_digit = 1;
+			}
+		} else if (ch == '.' && saw_digit) {
+			if (octets == 4)
+				return (0);
+			*++tp = 0;
+			saw_digit = 0;
+		} else
+			return (0);
+	}
+	if (octets < 4)
+		return (0);
+	memcpy(dst, tmp, NS_INADDRSZ);
+	return (1);
+}
+#endif
+
+#ifdef AF_INET6
+/* int
+ * inet_pton6(src, dst)
+ *	convert presentation level address to network order binary form.
+ * return:
+ *	1 if `src' is a valid [RFC1884 2.2] address, else 0.
+ * notice:
+ *	(1) does not touch `dst' unless it's returning 1.
+ *	(2) :: in a full address is silently ignored.
+ * credit:
+ *	inspired by Mark Andrews.
+ * author:
+ *	Paul Vixie, 1996.
+ */
+static int
+inet_pton6(src, dst)
+	const char *src;
+	u_char *dst;
+{
+	static const char xdigits_l[] = "0123456789abcdef",
+			  xdigits_u[] = "0123456789ABCDEF";
+	u_char tmp[NS_IN6ADDRSZ], *tp, *endp, *colonp;
+	const char *xdigits, *curtok;
+	int ch, saw_xdigit;
+	u_int val;
+
+	memset((tp = tmp), '\0', NS_IN6ADDRSZ);
+	endp = tp + NS_IN6ADDRSZ;
+	colonp = NULL;
+	/* Leading :: requires some special handling. */
+	if (*src == ':')
+		if (*++src != ':')
+			return (0);
+	curtok = src;
+	saw_xdigit = 0;
+	val = 0;
+	while ((ch = *src++) != '\0') {
+		const char *pch;
+
+		if ((pch = strchr((xdigits = xdigits_l), ch)) == NULL)
+			pch = strchr((xdigits = xdigits_u), ch);
+		if (pch != NULL) {
+			val <<= 4;
+			val |= (pch - xdigits);
+			if (val > 0xffff)
+				return (0);
+			saw_xdigit = 1;
+			continue;
+		}
+		if (ch == ':') {
+			curtok = src;
+			if (!saw_xdigit) {
+				if (colonp)
+					return (0);
+				colonp = tp;
+				continue;
+			} else if (*src == '\0') {
+				return (0);
+			}
+			if (tp + NS_INT16SZ > endp)
+				return (0);
+			*tp++ = (u_char) (val >> 8) & 0xff;
+			*tp++ = (u_char) val & 0xff;
+			saw_xdigit = 0;
+			val = 0;
+			continue;
+		}
+		if (ch == '.' && ((tp + NS_INADDRSZ) <= endp) &&
+		    inet_pton4(curtok, tp) > 0) {
+			tp += NS_INADDRSZ;
+			saw_xdigit = 0;
+			break;	/* '\0' was seen by inet_pton4(). */
+		}
+		return (0);
+	}
+	if (saw_xdigit) {
+		if (tp + NS_INT16SZ > endp)
+			return (0);
+		*tp++ = (u_char) (val >> 8) & 0xff;
+		*tp++ = (u_char) val & 0xff;
+	}
+	if (colonp != NULL) {
+		/*
+		 * Since some memmove()'s erroneously fail to handle
+		 * overlapping regions, we'll do the shift by hand.
+		 */
+		const int n = (int) (tp - colonp);
+		int i;
+
+		if (tp == endp)
+			return (0);
+		for (i = 1; i <= n; i++) {
+			endp[- i] = colonp[n - i];
+			colonp[n - i] = 0;
+		}
+		tp = endp;
+	}
+	if (tp != endp)
+		return (0);
+	memcpy(dst, tmp, NS_IN6ADDRSZ);
+	return (1);
+}
+#endif
+
+/*
+ * Editor modelines  -  http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */

--- a/src/windows/inet_v6defs.h
+++ b/src/windows/inet_v6defs.h
@@ -1,0 +1,65 @@
+/* inet_v6defs.h
+ *
+ * Wireshark - Network traffic analyzer
+ * By Gerald Combs <gerald@wireshark.org>
+ * Copyright 1998 Gerald Combs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __INET_V6DEFS_H__
+#define __INET_V6DEFS_H__
+
+#include "ws_symbol_export.h"
+
+/*
+ * Versions of "inet_pton()" and "inet_ntop()", for the benefit of OSes that
+ * don't have it.
+ */
+
+/*  Windows does not have inet_pton() and inet_ntop() until Vista.  In order
+ *  to allow binaries compiled on Vista or later to work on pre-Vista Windows
+ *  (without resorting to fragile link ordering tricks), we give our versions
+ *  of those functions Wireshark-specific names.
+ */
+#ifdef _WIN32
+#define inet_pton ws_inet_pton
+#define inet_ntop ws_inet_ntop
+#endif
+
+WS_DLL_PUBLIC int inet_pton(int af, const char *src, void *dst);
+#ifndef HAVE_INET_NTOP_PROTO
+WS_DLL_PUBLIC const char *inet_ntop(int af, const void *src, char *dst,
+    size_t size);
+#endif
+
+/*
+ * Those OSes may also not have AF_INET6, so declare it here if it's not
+ * already declared, so that we can pass it to "inet_ntop()" and "inet_pton()".
+ */
+#ifndef AF_INET6
+#define	AF_INET6	127	/* pick a value unlikely to duplicate an existing AF_ value */
+#endif
+
+/*
+ * And if __P isn't defined, define it here, so we can use it in
+ * "inet_ntop.c" and "inet_pton.c" (rather than having to change them
+ * not to use it).
+ */
+#ifndef __P
+#define __P(args)	args
+#endif
+
+#endif

--- a/src/windows/ws_symbol_export.h
+++ b/src/windows/ws_symbol_export.h
@@ -1,0 +1,196 @@
+/*
+ * Cross platform defines for exporting symbols from shared libraries
+ *
+ * Wireshark - Network traffic analyzer
+ * By Balint Reczey <balint@balintreczey.hu>
+ * Copyright 2013 Balint Reczey
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/** Reset symbol export behavior.
+ * If you {un}define WS_BUILD_DLL on the fly you'll have to define this
+ * as well.
+ */
+#ifdef RESET_SYMBOL_EXPORT
+
+#ifdef SYMBOL_EXPORT_H
+#undef SYMBOL_EXPORT_H
+#endif
+
+#ifdef WS_DLL_PUBLIC
+#undef WS_DLL_PUBLIC
+#endif
+
+#ifdef WS_DLL_PUBLIC_DEF
+#undef WS_DLL_PUBLIC_DEF
+#endif
+
+#ifdef WS_DLL_LOCAL
+#undef WS_DLL_LOCAL
+#endif
+
+#endif /* RESET_SYMBOL_EXPORT */
+
+#ifndef SYMBOL_EXPORT_H
+#define SYMBOL_EXPORT_H
+
+/*
+ * NOTE: G_HAVE_GNUC_VISIBILITY is defined only if all of
+ *
+ *    __attribute__ ((visibility ("hidden")))
+ *
+ *    __attribute__ ((visibility ("internal")))
+ *
+ *    __attribute__ ((visibility ("protected")))
+ *
+ *    __attribute__ ((visibility ("default")))
+ *
+ * are supported, and at least some versions of GCC from Apple support
+ * "default" and "hidden" but not "internal" or "protected", so it
+ * shouldn't be used to determine whether "hidden" or "default" is
+ * supported.
+ *
+ * This also means that we shouldn't use G_GNUC_INTERNAL instead of
+ * WS_DLL_LOCAL, as GLib uses G_HAVE_GNUC_VISIBILITY to determine
+ * whether to use __attribute__ ((visibility ("hidden"))) for
+ * G_GNUC_INTERNAL, and that will not use it even with compilers
+ * that support it.
+ */
+
+/* Originally copied from GCC Wiki at http://gcc.gnu.org/wiki/Visibility */
+#if defined _WIN32 || defined __CYGWIN__
+  /* Compiling for Windows, so we use the Windows DLL declarations. */
+  #ifdef WS_BUILD_DLL
+    /*
+     * Building a DLL; for all definitions, we want dllexport, and
+     * (presumably so source from DLL and source from a program using the
+     * DLL can both include a header that declares APIs and exported data
+     * for the DLL), for declarations, either dllexport or dllimport will
+     * work (they mean the same thing for a declaration when building a DLL).
+     */
+    #ifdef __GNUC__
+      /* GCC */
+#define WS_DLL_PUBLIC_DEF __attribute__ ((dllexport))
+    #else /* ! __GNUC__ */
+      /*
+       * Presumably MSVC.
+       * Note: actually gcc seems to also support this syntax.
+       */
+#define WS_DLL_PUBLIC_DEF __declspec(dllexport)
+    #endif /* __GNUC__ */
+  #else /* WS_BUILD_DLL */
+    /*
+     * Building a program; we should only see declarations, not definitions,
+     * with WS_DLL_PUBLIC, and they all represent APIs or data imported
+     * from a DLL, so use dllimport.
+     *
+     * For functions, export shouldn't be necessary; for data, it might
+     * be necessary, e.g. if what's declared is an array whose size is
+     * not given in the declaration.
+     */
+    #ifdef __GNUC__
+      /* GCC */
+#define WS_DLL_PUBLIC_DEF __attribute__ ((dllimport))
+    #elif ! (defined ENABLE_STATIC) /* ! __GNUC__ */
+      /*
+       * Presumably MSVC, and we're not building all-static.
+       * Note: actually gcc seems to also support this syntax.
+       */
+#define WS_DLL_PUBLIC_DEF __declspec(dllimport)
+    #else /* ! __GNUC__  && ENABLE_STATIC */
+      /*
+       * Presumably MSVC, and we're building all-static, so we're
+       * not building any DLLs.
+       */
+#define WS_DLL_PUBLIC_DEF
+    #endif /* __GNUC__ */
+  #endif /* WS_BUILD_DLL */
+
+  /*
+   * Symbols in a DLL are *not* exported unless they're specifically
+   * flagged as exported, so, for a non-static but non-exported
+   * symbol, we don't have to do anything.
+   */
+  #define WS_DLL_LOCAL
+#else /* defined _WIN32 || defined __CYGWIN__ */
+  /*
+   * Compiling for UN*X, where the dllimport and dllexport stuff
+   * is neither necessary nor supported; just specify the
+   * visibility if we have a compiler that claims compatibility
+   * with GCC 4 or later.
+   */
+  #if __GNUC__ >= 4
+    /*
+     * Symbols exported from libraries.
+     */
+#define WS_DLL_PUBLIC_DEF __attribute__ ((visibility ("default")))
+
+    /*
+     * Non-static symbols *not* exported from libraries.
+     */
+#define WS_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else /* ! __GNUC__ >= 4 */
+    /*
+     * We have no way to make stuff not explicitly marked as
+     * visible invisible outside a library, but we might have
+     * a way to make stuff explicitly marked as local invisible
+     * outside the library.
+     *
+     * This was lifted from GLib; see above for why we don't use
+     * G_GNUC_INTERNAL.
+     */
+    #if defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
+      /* This supports GCC-style __attribute__ ((visibility (XXX))) */
+      #define WS_DLL_PUBLIC_DEF __attribute__ ((visibility ("default")))
+      #define WS_DLL_LOCAL __attribute__ ((visibility ("hidden")))
+    #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550)
+      /* This doesn't, but supports __global and __hidden */
+      #define WS_DLL_PUBLIC_DEF __global
+      #define WS_DLL_LOCAL __hidden
+    #else /* not Sun C with "hidden" support */
+      #define WS_DLL_PUBLIC_DEF
+      #define WS_DLL_LOCAL
+    #endif
+  #endif /* __GNUC__ >= 4 */
+#endif
+
+/*
+ * You *must* use this for exported data *declarations*; if you use
+ * WS_DLL_PUBLIC_DEF, some compilers, such as MSVC++, will complain
+ * about array definitions with no size.
+ *
+ * You must *not* use this for exported data *definitions*, as that
+ * will, for some compilers, cause warnings about items being initialized
+ * and declared extern.
+ *
+ * Either can be used for exported *function* declarations and definitions.
+ */
+#define WS_DLL_PUBLIC  WS_DLL_PUBLIC_DEF extern
+
+#endif /* SYMBOL_EXPORT_H */
+
+/*
+ * Editor modelines  -  http://www.wireshark.org/tools/modelines.html
+ *
+ * Local Variables:
+ * c-basic-offset: 2
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=2 tabstop=8 expandtab:
+ * :indentSize=2:tabSize=8:noTabs=true:
+ */


### PR DESCRIPTION
This PR adds an implementation of `inet_pton` for Windows, as it's missing in the MinGW toolchain used by R.

The implementation from WireShark is used; those files are GPL-2 but we should probably make mention of them (e.g. in `LICENSE` + as copyright holders?)

NOTE: This PR is not entirely complete, as there are Boost issues to sort out as well. With this PR, I can successfully compile `iptools` but it doesn't link due to missing boost libraries on my machine.

# TODO

- [ ] Bring in Boost ASIO dynamically (as it's not part of BH), or determine if it's available on the CRAN build servers.
- [ ] Note that `boost_regex` and `boost_system` are required (these aren't included as part of `BH`); pray that these are available on CRAN.