### PR TITLE
Avoid shifting by 32 bits

### DIFF
--- a/src/asio_bindings.cpp
+++ b/src/asio_bindings.cpp
@@ -225,7 +225,7 @@ std::vector < std::string > asio_bindings::single_ip_to_dns(std::string ip_addre
 
 bool asio_bindings::single_ip_in_range(std::string ip_address, std::string range){
 
-  unsigned int first_ip;
+  unsigned int first_ip, mask;
   int slash_val;
   char range_copy[24];
   char *slash_pos;
@@ -244,7 +244,8 @@ bool asio_bindings::single_ip_in_range(std::string ip_address, std::string range
 
     slash_val = atoi(slash_pos);
     first_ip = asio::ip::address_v4::from_string(std::string(range_copy)).to_ulong();
-    unsigned int mask = ~(0xffffffff >> slash_val);
+    // shifting by 32 bits is undefined
+    mask = slash_val == 32 ? 0xffffffff : ~(0xffffffff >> slash_val);
     unsigned int cidr_int = first_ip & mask ;
 
     output = ((asio::ip::address_v4::from_string(ip_address).to_ulong() & mask) == cidr_int);

--- a/tests/testthat/test_ip_in_range.R
+++ b/tests/testthat/test_ip_in_range.R
@@ -21,6 +21,11 @@ test_that("ip_in_range works with multiple IP values and multiple range values",
   expect_that(result, equals(c(TRUE,TRUE)))
 })
 
+test_that("/32s are handled correctly", {
+  result <- ip_in_range(c("8.8.8.8", "127.0.0.1"), "8.8.8.8/32")
+  expect_that(result, equals(c(TRUE, FALSE)))
+})
+
 test_that("ip_in_range error handlers function",{
   result <- ip_in_range("asdasdas12","aaaah")
   expect_that(is.vector(result, "logical"), equals(TRUE))


### PR DESCRIPTION
Shifting a 32-bit integer by 32 bits permits undefined behavior, leading to the bug described in #26 (all comparisons to a /32 are TRUE).

Fixes #26.