### PR TITLE
Switch one sprintf to snprintf

### DIFF
--- a/src/asio_bindings.cpp
+++ b/src/asio_bindings.cpp
@@ -372,7 +372,7 @@ std::vector < std::string > asio_bindings::expand_ipv6_(std::vector < std::strin
     try{
       //      output[i] = asio::ip::address_v6::from_string(ip_addresses[i]).to_string();
       v = asio::ip::address_v6::from_string(ip_addresses[i]).to_bytes();
-      (void)sprintf(str, "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+      (void)snprintf(str, 50, "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
        (uint8_t)v[0], (uint8_t)v[1], (uint8_t)v[2], (uint8_t)v[3], (uint8_t)v[4], (uint8_t)v[5], (uint8_t)v[6], (uint8_t)v[7], (uint8_t)v[8], (uint8_t)v[9], (uint8_t)v[10], (uint8_t)v[11], (uint8_t)v[12], (uint8_t)v[13], (uint8_t)v[14], (uint8_t)v[15]);
       output[i] = std::string(str);
     } catch (...) {


### PR DESCRIPTION
Via [this issue ticket](https://github.com/eddelbuettel/asioheaders/issues/8) Winston shared with me an email from CRAN / BDR about `(v)?sprintf` being detected now, with some leads into `AsioHeaders`.  I have just uploaded a new version of `AsioHeaders` to CRAN which should hopefully progress smoothly.

`iptools` had an issue of its own which was easy to fix and is addressed here by switching a single `sprintf` to `snprintf`.